### PR TITLE
Only update the quota if the Rate-Limit header has been received

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geocoding"
 description = "Geocoding library for Rust"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Stephan Hügel <urschrei@gmail.com>", "Blake Grotewold <hello@grotewold.me>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/rust-geocoding"


### PR DESCRIPTION
OpenCage paid tier customers don't have a daily rate limit, and query responses against their API keys do not return the `X-RateLimit-Limit` header or contain the `rate` field in the JSON response. This PR fixes what would have been a panic if these were missing.