### PR TITLE
Add methods for full responses

### DIFF
--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -1,7 +1,9 @@
 //! The [OpenCage Geocoding](https://geocoder.opencagedata.com/) provider.
 //!
 //! Please see the [API documentation](https://geocoder.opencagedata.com/api) for details.
-//! Note that rate limits apply to the free tier; the remaining daily quota can be retrieved
+//! Note that rate limits apply to the free tier:
+//! there is a [rate-limit](https://geocoder.opencagedata.com/api#rate-limiting) of 1 request per second,
+//! and a quota of calls allowed per 24-hour period. The remaining daily quota can be retrieved
 //! Using the [`remaining_calls()`](struct.Opencage.html#method.remaining_calls) method. If you
 //! are a paid tier user, this value will not be updated, and will remain `None`.
 //! ### A Note on Coordinate Order
@@ -61,8 +63,9 @@ impl Opencage {
     }
     /// Retrieve the remaining API calls in your daily quota
     ///
-    /// Initially, this value is `None`. Any OpenCage API call will update this
-    /// value to reflect the remaining quota for the API key. See the [API docs](https://geocoder.opencagedata.com/api#rate-limiting) for details.
+    /// Initially, this value is `None`. Any OpenCage API call using a "Free Tier" key
+    /// will update this value to reflect the remaining quota for the API key.
+    /// See the [API docs](https://geocoder.opencagedata.com/api#rate-limiting) for details.
     pub fn remaining_calls(&self) -> Option<i32> {
         *self.remaining.lock().unwrap()
     }

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -136,12 +136,12 @@ impl Opencage {
     ///
     /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
     /// let address = "UCL CASA";
-    /// // restrict the search space
-    /// let bbox = InputBounds {
-    ///     minimum_lonlat: Point::new(-0.13806939125061035, 51.51989264641164),
-    ///     maximum_lonlat: Point::new(-0.13427138328552246, 51.52319711775629),
-    /// };
-    /// let res = oc.forward_full(&address, &Some(bbox)).unwrap();
+    /// // restrict the search space. An `into()` conversion exists for `Point` tuples
+    /// let bbox = (
+    ///     Point::new(-0.13806939125061035, 51.51989264641164),
+    ///     Point::new(-0.13427138328552246, 51.52319711775629),
+    /// );
+    /// let res = oc.forward_full(&address, &Some(bbox.into())).unwrap();
     /// let first_result = &res.results[0];
     /// // the first result is correct
     /// assert_eq!(first_result.formatted, "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom");
@@ -517,6 +517,7 @@ where
     pub maximum_lonlat: Point<T>,
 }
 
+/// Convert borrowed input bounds into the correct String representation
 impl<'a, T> From<&'a InputBounds<T>> for String
 where
     T: Float,
@@ -530,6 +531,19 @@ where
             ip.maximum_lonlat.x().to_f64().unwrap().to_string(),
             ip.maximum_lonlat.y().to_f64().unwrap().to_string()
         )
+    }
+}
+
+/// Convert a tuple of Points into search bounds
+impl<T> From<(Point<T>, Point<T>)> for InputBounds<T>
+where
+    T: Float,
+{
+    fn from(t: (Point<T>, Point<T>)) -> InputBounds<T> {
+        InputBounds {
+            minimum_lonlat: t.0,
+            maximum_lonlat: t.1,
+        }
     }
 }
 
@@ -572,11 +586,11 @@ mod test {
     fn forward_full_test() {
         let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
         let address = "UCL CASA";
-        let bbox = InputBounds {
-            minimum_lonlat: Point::new(-0.13806939125061035, 51.51989264641164),
-            maximum_lonlat: Point::new(-0.13427138328552246, 51.52319711775629),
-        };
-        let res = oc.forward_full(&address, &Some(bbox)).unwrap();
+        let bbox = (
+            Point::new(-0.13806939125061035, 51.51989264641164),
+            Point::new(-0.13427138328552246, 51.52319711775629),
+        );
+        let res = oc.forward_full(&address, &Some(bbox.into())).unwrap();
         let first_result = &res.results[0];
         assert_eq!(
             first_result.formatted,

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -99,10 +99,11 @@ where
         let res: OpencageResponse<T> = resp.json()?;
         // it's OK to index into this vec, because reverse-geocoding only returns a single result
         let address = &res.results[0];
-        let headers = resp.headers().get::<XRatelimitRemaining>().unwrap();
-        let mut lock = self.remaining.try_lock();
-        if let Ok(ref mut mutex) = lock {
-            **mutex = Some(**headers)
+        if let Some(headers) = resp.headers().get::<XRatelimitRemaining>() {
+            let mut lock = self.remaining.try_lock();
+            if let Ok(ref mut mutex) = lock {
+                **mutex = Some(**headers)
+            }
         }
         Ok(address.formatted.to_string())
     }
@@ -135,7 +136,6 @@ where
                 **mutex = Some(**headers)
             }
         }
-        // let headers = resp.headers().get::<XRatelimitRemaining>().unwrap();
         Ok(res.results
             .iter()
             .map(|res| Point::new(res.geometry["lng"], res.geometry["lat"]))

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -488,7 +488,7 @@ where
     fn from(ip: InputBounds<T>) -> String {
         // OpenCage expects lon, lat order here, for some reason
         format!(
-            "{}, {}, {}, {}",
+            "{},{},{},{}",
             ip.minimum_lonlat.x().to_f64().unwrap().to_string(),
             ip.minimum_lonlat.y().to_f64().unwrap().to_string(),
             ip.maximum_lonlat.x().to_f64().unwrap().to_string(),

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -1,10 +1,11 @@
 //! The [OpenCage Geocoding](https://geocoder.opencagedata.com/) provider.
 //!
+//! Geocoding methods are implemented on the [`Opencage`](struct.Opencage.html) struct.
 //! Please see the [API documentation](https://geocoder.opencagedata.com/api) for details.
 //! Note that rate limits apply to the free tier:
 //! there is a [rate-limit](https://geocoder.opencagedata.com/api#rate-limiting) of 1 request per second,
 //! and a quota of calls allowed per 24-hour period. The remaining daily quota can be retrieved
-//! Using the [`remaining_calls()`](struct.Opencage.html#method.remaining_calls) method. If you
+//! using the [`remaining_calls()`](struct.Opencage.html#method.remaining_calls) method. If you
 //! are a paid tier user, this value will not be updated, and will remain `None`.
 //! ### A Note on Coordinate Order
 //! This provider's API documentation shows all coordinates in `[Latitude, Longitude]` order.

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -165,7 +165,7 @@ impl Opencage {
             ("no_record", &record),
         ];
         // If search bounds are passed, use them
-        if let &Some(ref bds) = bounds {
+        if let Some(ref bds) = *bounds {
             bd = String::from(bds);
             query.push(("bounds", &bd));
         }

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -140,7 +140,7 @@ impl Opencage {
     ///     minimum_lonlat: Point::new(-0.13806939125061035, 51.51989264641164),
     ///     maximum_lonlat: Point::new(-0.13427138328552246, 51.52319711775629),
     /// };
-    /// let res = oc.forward_full(&address, Some(bbox)).unwrap();
+    /// let res = oc.forward_full(&address, &Some(bbox)).unwrap();
     /// let first_result = &res.results[0];
     /// // the first result is correct
     /// assert_eq!(first_result.formatted, "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom");
@@ -148,7 +148,7 @@ impl Opencage {
     pub fn forward_full<T>(
         &self,
         place: &str,
-        bounds: Option<InputBounds<T>>,
+        bounds: &Option<InputBounds<T>>,
     ) -> reqwest::Result<OpencageResponse<T>>
     where
         T: Float,
@@ -165,7 +165,7 @@ impl Opencage {
             ("no_record", &record),
         ];
         // If search bounds are passed, use them
-        if let Some(bds) = bounds {
+        if let &Some(ref bds) = bounds {
             bd = String::from(bds);
             query.push(("bounds", &bd));
         }
@@ -516,11 +516,11 @@ where
     pub maximum_lonlat: Point<T>,
 }
 
-impl<T> From<InputBounds<T>> for String
+impl<'a, T> From<&'a InputBounds<T>> for String
 where
     T: Float,
 {
-    fn from(ip: InputBounds<T>) -> String {
+    fn from(ip: &InputBounds<T>) -> String {
         // OpenCage expects lon, lat order here, for some reason
         format!(
             "{},{},{},{}",
@@ -575,7 +575,7 @@ mod test {
             minimum_lonlat: Point::new(-0.13806939125061035, 51.51989264641164),
             maximum_lonlat: Point::new(-0.13427138328552246, 51.52319711775629),
         };
-        let res = oc.forward_full(&address, Some(bbox)).unwrap();
+        let res = oc.forward_full(&address, &Some(bbox)).unwrap();
         let first_result = &res.results[0];
         assert_eq!(
             first_result.formatted,

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -19,6 +19,7 @@
 //! let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
 //! let p = Point::new(2.12870, 41.40139);
 //! let res = oc.reverse(&p);
+//! // "Carrer de Calatrava, 68, 08017 Barcelona, Spain"
 //! println!("{:?}", res.unwrap());
 //! ```
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
This PR adds:
- methods which receive full OpenCage responses for forward- and reverse geocoding
    - an optional bounding box which restricts the search space for forward-geocoding
- `Debug` is now available on all response structs
- tests and doctest examples for all the above
-  more polishing of the docs generally

I haven't bumped the version, since we haven't cut a release yet anyway.