### PR TITLE
Stub remote HTTP requests in tests with mockito

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ reqwest = { version = "0.12", default-features = false, features = [
 [features]
 default = ["reqwest/default"]
 rustls-tls = ["reqwest/rustls-tls"]
+
+[dev-dependencies]
+mockito = "1.7"

--- a/src/geoadmin.rs
+++ b/src/geoadmin.rs
@@ -448,10 +448,88 @@ pub struct ReverseLocationAttributes {
 #[cfg(test)]
 mod test {
     use super::*;
+    use mockito::{Matcher, ServerGuard};
+    use serde_json::json;
+
+    fn make_geoadmin(server: &ServerGuard) -> GeoAdmin {
+        GeoAdmin::new().with_endpoint(&format!("{}/", server.url()))
+    }
+
+    fn forward_body(x: f64, y: f64, lon: f64, lat: f64, label: &str) -> String {
+        json!({
+            "features": [{
+                "properties": {
+                    "origin": "address",
+                    "geom_quadindex": "021300220302203002031",
+                    "weight": 1512u32,
+                    "zoomlevel": 10u32,
+                    "lon": lon,
+                    "detail": "seftigenstrasse 264 3084 wabern",
+                    "rank": 7u32,
+                    "lat": lat,
+                    "num": 264usize,
+                    "x": x,
+                    "y": y,
+                    "label": label,
+                }
+            }]
+        })
+        .to_string()
+    }
+
+    fn reverse_body(strname_deinr: &str, dplz4: u32, dplzname: &str) -> String {
+        json!({
+            "results": [{
+                "featureId": "1272199_0",
+                "layerBodId": "ch.bfs.gebaeude_wohnungs_register",
+                "layerName": "Register of Buildings and Dwellings",
+                "properties": {
+                    "egid": null,
+                    "ggdenr": 351u32,
+                    "ggdename": "Köniz",
+                    "gdekt": "BE",
+                    "edid": null,
+                    "egaid": 0u32,
+                    "deinr": null,
+                    "dplz4": dplz4,
+                    "dplzname": dplzname,
+                    "egrid": null,
+                    "esid": 0u32,
+                    "strname": [],
+                    "strsp": [],
+                    "strname_deinr": strname_deinr,
+                    "label": strname_deinr,
+                }
+            }]
+        })
+        .to_string()
+    }
+
+    fn mock_path(server: &mut ServerGuard, path: &str, body: String) -> mockito::Mock {
+        server
+            .mock("GET", Matcher::Regex(format!("^{}.*", path)))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create()
+    }
 
     #[test]
     fn new_with_sr_forward_test() {
-        let geoadmin = GeoAdmin::new().with_sr("2056");
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/SearchServer",
+            forward_body(
+                1_197_427.0,
+                2_600_968.75,
+                7.451352119445801,
+                46.92793655395508,
+                "Seftigenstrasse 264 <b>3084 Wabern</b>",
+            ),
+        );
+
+        let geoadmin = make_geoadmin(&server).with_sr("2056");
         let address = "Seftigenstrasse 264, 3084 Wabern";
         let res = geoadmin.forward(address);
         assert_eq!(res.unwrap(), vec![Point::new(2_600_968.75, 1_197_427.0)]);
@@ -459,8 +537,20 @@ mod test {
 
     #[test]
     fn new_with_endpoint_forward_test() {
-        let geoadmin =
-            GeoAdmin::new().with_endpoint("https://api3.geo.admin.ch/rest/services/api/");
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/SearchServer",
+            forward_body(
+                7.451352119445801,
+                46.92793655395508,
+                7.451352119445801,
+                46.92793655395508,
+                "Seftigenstrasse 264 <b>3084 Wabern</b>",
+            ),
+        );
+
+        let geoadmin = GeoAdmin::new().with_endpoint(&format!("{}/", server.url()));
         let address = "Seftigenstrasse 264, 3084 Wabern";
         let res = geoadmin.forward(address);
         assert_eq!(
@@ -471,7 +561,20 @@ mod test {
 
     #[test]
     fn with_sr_forward_full_test() {
-        let geoadmin = GeoAdmin::new().with_sr("2056");
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/SearchServer",
+            forward_body(
+                1_197_427.0,
+                2_600_968.75,
+                7.451352119445801,
+                46.92793655395508,
+                "Seftigenstrasse 264 <b>3084 Wabern</b>",
+            ),
+        );
+
+        let geoadmin = make_geoadmin(&server).with_sr("2056");
         let bbox = InputBounds::new((2_600_967.75, 1_197_426.0), (2_600_969.75, 1_197_428.0));
         let params = GeoAdminParams::new("Seftigenstrasse Bern")
             .with_origins("address")
@@ -487,7 +590,20 @@ mod test {
 
     #[test]
     fn forward_full_test() {
-        let geoadmin = GeoAdmin::new();
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/SearchServer",
+            forward_body(
+                7.451352119445801,
+                46.92793655395508,
+                7.451352119445801,
+                46.92793655395508,
+                "Seftigenstrasse 264 <b>3084 Wabern</b>",
+            ),
+        );
+
+        let geoadmin = make_geoadmin(&server);
         let bbox = InputBounds::new((7.4513398, 46.92792859), (7.4513662, 46.9279467));
         let params = GeoAdminParams::new("Seftigenstrasse Bern")
             .with_origins("address")
@@ -503,7 +619,20 @@ mod test {
 
     #[test]
     fn forward_test() {
-        let geoadmin = GeoAdmin::new();
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/SearchServer",
+            forward_body(
+                7.451352119445801,
+                46.92793655395508,
+                7.451352119445801,
+                46.92793655395508,
+                "Seftigenstrasse 264 <b>3084 Wabern</b>",
+            ),
+        );
+
+        let geoadmin = make_geoadmin(&server);
         let address = "Seftigenstrasse 264, 3084 Wabern";
         let res = geoadmin.forward(address);
         assert_eq!(
@@ -514,7 +643,14 @@ mod test {
 
     #[test]
     fn with_sr_reverse_test() {
-        let geoadmin = GeoAdmin::new().with_sr("2056");
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/MapServer/identify",
+            reverse_body("Seftigenstrasse 264", 3084, "Wabern"),
+        );
+
+        let geoadmin = make_geoadmin(&server).with_sr("2056");
         let p = Point::new(2_600_968.75, 1_197_427.0);
         let res = geoadmin.reverse(&p);
         assert_eq!(
@@ -524,9 +660,15 @@ mod test {
     }
 
     #[test]
-    #[ignore = "https://github.com/georust/geocoding/pull/45#issuecomment-1592395700"]
     fn reverse_test() {
-        let geoadmin = GeoAdmin::new();
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/MapServer/identify",
+            reverse_body("Seftigenstrasse 264", 3084, "Wabern"),
+        );
+
+        let geoadmin = make_geoadmin(&server);
         let p = Point::new(7.451352119445801, 46.92793655395508);
         let res = geoadmin.reverse(&p);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,15 @@ pub enum GeocodingError {
 ///
 /// ```
 /// use geocoding::{Opencage, Point, Reverse};
+/// # let mut server = mockito::Server::new();
+/// # let _m = server.mock("GET", mockito::Matcher::Any)
+/// #     .with_header("content-type", "application/json")
+/// #     .with_body(r#"{"documentation":"","licenses":[],"results":[{"components":{"road":"Carrer de Calatrava"},"confidence":10,"formatted":"Carrer de Calatrava, 64, 08017 Barcelona, Spain","geometry":{"lat":41.4014067,"lng":2.1287224}}],"status":{"message":"OK","code":200},"stay_informed":{},"thanks":"","timestamp":{"created_http":"","created_unix":0},"total_results":1}"#)
+/// #     .create();
 ///
 /// let p = Point::new(2.12870, 41.40139);
 /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+/// # let oc = Opencage::new_with_endpoint("dcdbf0d783374909b3debee728c7cc10".to_string(), format!("{}/geocode/v1/json", server.url()));
 /// let res = oc.reverse(&p).unwrap();
 /// assert_eq!(
 ///     res,
@@ -102,8 +108,14 @@ where
 ///
 /// ```
 /// use geocoding::{Coord, Forward, Opencage, Point};
+/// # let mut server = mockito::Server::new();
+/// # let _m = server.mock("GET", mockito::Matcher::Any)
+/// #     .with_header("content-type", "application/json")
+/// #     .with_body(r#"{"documentation":"","licenses":[],"results":[{"components":{"road":""},"confidence":10,"formatted":"Schwabing, Munich, Germany","geometry":{"lat":48.1700887,"lng":11.5884858}}],"status":{"message":"OK","code":200},"stay_informed":{},"thanks":"","timestamp":{"created_http":"","created_unix":0},"total_results":1}"#)
+/// #     .create();
 ///
 /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+/// # let oc = Opencage::new_with_endpoint("dcdbf0d783374909b3debee728c7cc10".to_string(), format!("{}/geocode/v1/json", server.url()));
 /// let address = "Schwabing, München";
 /// let res: Vec<Point<f64>> = oc.forward(address).unwrap();
 /// assert_eq!(

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -16,8 +16,14 @@
 //!
 //! ```
 //! use geocoding::{Opencage, Point, Reverse};
+//! # let mut server = mockito::Server::new();
+//! # let _m = server.mock("GET", mockito::Matcher::Any)
+//! #     .with_header("content-type", "application/json")
+//! #     .with_body(r#"{"documentation":"","licenses":[],"results":[{"components":{"road":"Carrer de Calatrava"},"confidence":10,"formatted":"Carrer de Calatrava, 64, 08017 Barcelone, Espagne","geometry":{"lat":41.4014067,"lng":2.1287224}}],"status":{"message":"OK","code":200},"stay_informed":{},"thanks":"","timestamp":{"created_http":"","created_unix":0},"total_results":1}"#)
+//! #     .create();
 //!
 //! let mut oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+//! # let mut oc = Opencage::new_with_endpoint("dcdbf0d783374909b3debee728c7cc10".to_string(), format!("{}/geocode/v1/json", server.url()));
 //! oc.parameters.language = Some("fr");
 //! let p = Point::new(2.12870, 41.40139);
 //! let res = oc.reverse(&p);
@@ -141,8 +147,14 @@ impl Opencage<'_> {
     ///
     ///```
     /// use geocoding::{Opencage, Point};
+    /// # let mut server = mockito::Server::new();
+    /// # let _m = server.mock("GET", mockito::Matcher::Any)
+    /// #     .with_header("content-type", "application/json")
+    /// #     .with_body(r#"{"documentation":"","licenses":[],"results":[{"components":{"road":"Carrer de Calatrava"},"confidence":10,"formatted":"Carrer de Calatrava, 64, 08017 Barcelona, Spain","geometry":{"lat":41.4014067,"lng":2.1287224}}],"status":{"message":"OK","code":200},"stay_informed":{},"thanks":"","timestamp":{"created_http":"","created_unix":0},"total_results":1}"#)
+    /// #     .create();
     ///
     /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+    /// # let oc = Opencage::new_with_endpoint("dcdbf0d783374909b3debee728c7cc10".to_string(), format!("{}/geocode/v1/json", server.url()));
     /// let p = Point::new(2.12870, 41.40139);
     /// // a full `OpencageResponse` struct
     /// let res = oc.reverse_full(&p).unwrap();
@@ -206,8 +218,14 @@ impl Opencage<'_> {
     ///
     ///```
     /// use geocoding::{Opencage, InputBounds, Point};
+    /// # let mut server = mockito::Server::new();
+    /// # let _m = server.mock("GET", mockito::Matcher::Any)
+    /// #     .with_header("content-type", "application/json")
+    /// #     .with_body(r#"{"documentation":"","licenses":[],"results":[{"components":{"road":"Tottenham Court Road"},"confidence":10,"formatted":"UCL, 90 Tottenham Court Road, London","geometry":{"lat":51.5215,"lng":-0.1361}}],"status":{"message":"OK","code":200},"stay_informed":{},"thanks":"","timestamp":{"created_http":"","created_unix":0},"total_results":1}"#)
+    /// #     .create();
     ///
     /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+    /// # let oc = Opencage::new_with_endpoint("dcdbf0d783374909b3debee728c7cc10".to_string(), format!("{}/geocode/v1/json", server.url()));
     /// let address = "UCL Centre for Advanced Spatial Analysis";
     /// // Optionally restrict the search space using a bounding box.
     /// // The first point is the bottom-left corner, the second is the top-right.
@@ -225,7 +243,13 @@ impl Opencage<'_> {
     /// // You can pass NOBOX if you don't need bounds.
     /// use geocoding::{Opencage, InputBounds, Point};
     /// use geocoding::opencage::{NOBOX};
+    /// # let mut server = mockito::Server::new();
+    /// # let _m = server.mock("GET", mockito::Matcher::Any)
+    /// #     .with_header("content-type", "application/json")
+    /// #     .with_body(r#"{"documentation":"","licenses":[],"results":[{"components":{"road":""},"confidence":10,"formatted":"Moabit, Berlin, Germany","geometry":{"lat":52.53,"lng":13.34}}],"status":{"message":"OK","code":200},"stay_informed":{},"thanks":"","timestamp":{"created_http":"","created_unix":0},"total_results":1}"#)
+    /// #     .create();
     /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+    /// # let oc = Opencage::new_with_endpoint("dcdbf0d783374909b3debee728c7cc10".to_string(), format!("{}/geocode/v1/json", server.url()));
     /// let address = "Moabit, Berlin";
     /// let res = oc.forward_full(&address, NOBOX).unwrap();
     /// let first_result = &res.results[0];
@@ -238,7 +262,13 @@ impl Opencage<'_> {
     /// ```
     /// // There are several ways to construct a Point, such as from a tuple
     /// use geocoding::{Opencage, InputBounds, Point};
+    /// # let mut server = mockito::Server::new();
+    /// # let _m = server.mock("GET", mockito::Matcher::Any)
+    /// #     .with_header("content-type", "application/json")
+    /// #     .with_body(r#"{"documentation":"","licenses":[],"results":[{"components":{"road":"Tottenham Court Road"},"confidence":10,"formatted":"UCL, 90 Tottenham Court Road, London","geometry":{"lat":51.5215,"lng":-0.1361}}],"status":{"message":"OK","code":200},"stay_informed":{},"thanks":"","timestamp":{"created_http":"","created_unix":0},"total_results":1}"#)
+    /// #     .create();
     /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+    /// # let oc = Opencage::new_with_endpoint("dcdbf0d783374909b3debee728c7cc10".to_string(), format!("{}/geocode/v1/json", server.url()));
     /// let address = "UCL Centre for Advanced Spatial Analysis";
     /// let bbox = InputBounds::new(
     ///     (-0.13806939125061035, 51.51989264641164),

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -99,6 +99,16 @@ pub struct Opencage<'a> {
 impl Opencage<'_> {
     /// Create a new OpenCage geocoding instance
     pub fn new(api_key: String) -> Self {
+        Opencage::new_with_endpoint(
+            api_key,
+            "https://api.opencagedata.com/geocode/v1/json".to_string(),
+        )
+    }
+
+    /// Create a new OpenCage geocoding instance with a custom endpoint.
+    ///
+    /// `endpoint` is the full JSON endpoint URL (i.e. `https://api.opencagedata.com/geocode/v1/json`).
+    pub fn new_with_endpoint(api_key: String, endpoint: String) -> Self {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, HeaderValue::from_static(UA_STRING));
         let client = Client::builder()
@@ -111,7 +121,7 @@ impl Opencage<'_> {
             api_key,
             client,
             parameters,
-            endpoint: "https://api.opencagedata.com/geocode/v1/json".to_string(),
+            endpoint,
             remaining: Arc::new(Mutex::new(None)),
         }
     }
@@ -636,10 +646,57 @@ where
 mod test {
     use super::*;
     use crate::Coord;
+    use mockito::{Matcher, ServerGuard};
+    use serde_json::json;
+
+    fn make_opencage(server: &ServerGuard) -> Opencage<'static> {
+        let endpoint = format!("{}/geocode/v1/json", server.url());
+        Opencage::new_with_endpoint("dummy-key".to_string(), endpoint)
+    }
+
+    fn canned_body(formatted: &str, lng: f64, lat: f64, road: &str) -> String {
+        json!({
+            "documentation": "https://opencagedata.com/api",
+            "licenses": [],
+            "rate": null,
+            "results": [{
+                "components": {"road": road},
+                "confidence": 10,
+                "formatted": formatted,
+                "geometry": {"lat": lat, "lng": lng}
+            }],
+            "status": {"message": "OK", "code": 200},
+            "stay_informed": {},
+            "thanks": "thanks",
+            "timestamp": {"created_http": "now", "created_unix": 1_523_277_181},
+            "total_results": 1
+        })
+        .to_string()
+    }
+
+    fn mock_get(server: &mut ServerGuard, body: String) -> mockito::Mock {
+        server
+            .mock("GET", Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create()
+    }
 
     #[test]
     fn reverse_test() {
-        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body(
+                "Carrer de Calatrava, 64, 08017 Barcelona, Spain",
+                2.1287224,
+                41.4014067,
+                "Carrer de Calatrava",
+            ),
+        );
+
+        let oc = make_opencage(&server);
         let p = Point::new(2.12870, 41.40139);
         let res = oc.reverse(&p);
         assert_eq!(
@@ -650,7 +707,18 @@ mod test {
 
     #[test]
     fn reverse_test_with_params() {
-        let mut oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body(
+                "Carrer de Calatrava, 64, 08017 Barcelone, Espagne",
+                2.1287224,
+                41.4014067,
+                "Carrer de Calatrava",
+            ),
+        );
+
+        let mut oc = make_opencage(&server);
         oc.parameters.language = Some("fr");
         let p = Point::new(2.12870, 41.40139);
         let res = oc.reverse(&p);
@@ -659,10 +727,17 @@ mod test {
             Some("Carrer de Calatrava, 64, 08017 Barcelone, Espagne".to_string())
         );
     }
+
     #[test]
     #[allow(deprecated)]
     fn forward_test() {
-        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body("Schwabing, München, Germany", 11.5884858, 48.1700887, ""),
+        );
+
+        let oc = make_opencage(&server);
         let address = "Schwabing, München";
         let res = oc.forward(address);
         assert_eq!(
@@ -673,18 +748,42 @@ mod test {
             })]
         );
     }
+
     #[test]
     fn reverse_full_test() {
-        let mut oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body(
+                "Carrer de Calatrava, 64, 08017 Barcelone, Espagne",
+                2.1287224,
+                41.4014067,
+                "Carrer de Calatrava",
+            ),
+        );
+
+        let mut oc = make_opencage(&server);
         oc.parameters.language = Some("fr");
         let p = Point::new(2.12870, 41.40139);
         let res = oc.reverse_full(&p).unwrap();
         let first_result = &res.results[0];
         assert_eq!(first_result.components["road"], "Carrer de Calatrava");
     }
+
     #[test]
     fn forward_full_test() {
-        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body(
+                "UCL Centre for Advanced Spatial Analysis, 90 Tottenham Court Road, London",
+                -0.1361,
+                51.5215,
+                "Tottenham Court Road",
+            ),
+        );
+
+        let oc = make_opencage(&server);
         let address = "UCL Centre for Advanced Spatial Analysis";
         let bbox = InputBounds {
             minimum_lonlat: Point::new(-0.13806939125061035, 51.51989264641164),
@@ -694,9 +793,21 @@ mod test {
         let first_result = &res.results[0];
         assert!(first_result.formatted.contains("UCL"));
     }
+
     #[test]
     fn forward_full_test_floats() {
-        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body(
+                "UCL Centre for Advanced Spatial Analysis, 90 Tottenham Court Road, London",
+                -0.1361,
+                51.5215,
+                "Tottenham Court Road",
+            ),
+        );
+
+        let oc = make_opencage(&server);
         let address = "UCL Centre for Advanced Spatial Analysis";
         let bbox = InputBounds::new(
             Point::new(-0.13806939125061035, 51.51989264641164),
@@ -709,9 +820,21 @@ mod test {
                 && first_result.formatted.contains("90 Tottenham Court Road")
         );
     }
+
     #[test]
     fn forward_full_test_pointfrom() {
-        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body(
+                "UCL Centre for Advanced Spatial Analysis, 90 Tottenham Court Road, London",
+                -0.1361,
+                51.5215,
+                "Tottenham Court Road",
+            ),
+        );
+
+        let oc = make_opencage(&server);
         let address = "UCL Centre for Advanced Spatial Analysis";
         let bbox = InputBounds::new(
             Point::from((-0.13806939125061035, 51.51989264641164)),
@@ -724,9 +847,21 @@ mod test {
                 && first_result.formatted.contains("90 Tottenham Court Road")
         );
     }
+
     #[test]
     fn forward_full_test_pointinto() {
-        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body(
+                "90 Tottenham Court Road, London",
+                -0.1361,
+                51.5215,
+                "Tottenham Court Road",
+            ),
+        );
+
+        let oc = make_opencage(&server);
         let address = "UCL Centre for Advanced Spatial Analysis";
         let bbox = InputBounds::new(
             (-0.13806939125061035, 51.51989264641164),
@@ -738,9 +873,16 @@ mod test {
             .formatted
             .contains("Tottenham Court Road, London"));
     }
+
     #[test]
     fn forward_full_test_nobox() {
-        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_get(
+            &mut server,
+            canned_body("Moabit, Berlin, Germany", 13.34, 52.53, ""),
+        );
+
+        let oc = make_opencage(&server);
         let address = "Moabit, Berlin, Germany";
         let res = oc.forward_full(address, NOBOX).unwrap();
         let first_result = &res.results[0];

--- a/src/openstreetmap.rs
+++ b/src/openstreetmap.rs
@@ -349,11 +349,59 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use mockito::{Matcher, ServerGuard};
+    use serde_json::{json, Value};
+
+    fn make_osm(server: &ServerGuard) -> Openstreetmap {
+        Openstreetmap::new_with_endpoint(format!("{}/", server.url()))
+    }
+
+    fn forward_body(display_name: &str, lng: f64, lat: f64, address: Option<Value>) -> String {
+        json!({
+            "type": "FeatureCollection",
+            "licence": "Data © OpenStreetMap contributors, ODbL 1.0.",
+            "features": [{
+                "type": "Feature",
+                "properties": {
+                    "place_id": 1u64,
+                    "osm_type": "way",
+                    "osm_id": 1u64,
+                    "display_name": display_name,
+                    "place_rank": 30u64,
+                    "category": "building",
+                    "type": "yes",
+                    "importance": 0.5,
+                    "address": address,
+                },
+                "bbox": [lng, lat, lng, lat],
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [lng, lat]
+                }
+            }]
+        })
+        .to_string()
+    }
+
+    fn mock_path(server: &mut ServerGuard, path: &str, body: String) -> mockito::Mock {
+        server
+            .mock("GET", Matcher::Regex(format!("^{}.*", path)))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create()
+    }
 
     #[test]
     fn new_with_endpoint_forward_test() {
-        let osm =
-            Openstreetmap::new_with_endpoint("https://nominatim.openstreetmap.org/".to_string());
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/search",
+            forward_body("Schwabing, München, Germany", 11.5884858, 48.1700887, None),
+        );
+
+        let osm = Openstreetmap::new_with_endpoint(format!("{}/", server.url()));
         let address = "Schwabing, München";
         let res = osm.forward(address);
         assert_eq!(res.unwrap(), vec![Point::new(11.5884858, 48.1700887)]);
@@ -361,7 +409,19 @@ mod test {
 
     #[test]
     fn forward_full_test() {
-        let osm = Openstreetmap::new();
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/search",
+            forward_body(
+                "UCL, 90 Tottenham Court Road, London",
+                -0.1361,
+                51.5215,
+                Some(json!({"city": "London"})),
+            ),
+        );
+
+        let osm = make_osm(&server);
         let viewbox = InputBounds::new(
             (-0.13806939125061035, 51.51989264641164),
             (-0.13427138328552246, 51.52319711775629),
@@ -378,7 +438,14 @@ mod test {
 
     #[test]
     fn forward_test() {
-        let osm = Openstreetmap::new();
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/search",
+            forward_body("Schwabing, München, Germany", 11.5884858, 48.1700887, None),
+        );
+
+        let osm = make_osm(&server);
         let address = "Schwabing, München";
         let res = osm.forward(address);
         assert_eq!(res.unwrap(), vec![Point::new(11.5884858, 48.1700887)]);
@@ -386,7 +453,19 @@ mod test {
 
     #[test]
     fn reverse_test() {
-        let osm = Openstreetmap::new();
+        let mut server = mockito::Server::new();
+        let _m = mock_path(
+            &mut server,
+            "/reverse",
+            forward_body(
+                "Barcelona, Barcelonès, Barcelona, Catalunya, Spain",
+                2.12870,
+                41.40139,
+                None,
+            ),
+        );
+
+        let osm = make_osm(&server);
         let p = Point::new(2.12870, 41.40139);
         let res = osm.reverse(&p);
         assert!(res


### PR DESCRIPTION
## Summary
- Adds `mockito` as a dev-dependency and rewrites the unit tests for the three providers (OpenCage, Nominatim, GeoAdmin) to serve canned JSON from a local `mockito::Server` instead of hitting the real APIs.
- Adds `Opencage::new_with_endpoint(api_key, endpoint)` (mirroring the existing `Openstreetmap::new_with_endpoint`) so the tests can point the provider at the mock URL without exposing the previously-private `endpoint` field through some other shim.
- Un-ignores the previously network-dependent GeoAdmin `reverse_test` (it was disabled in #45, the failure was a quirk of the live endpoint — irrelevant now that the response is stubbed).

This removes the test suite's dependency on the OpenCage demo API key, the Nominatim usage policy / rate-limit, and the GeoAdmin endpoint being reachable from CI.

## Test plan
- [x] `cargo test --lib` — all 20 tests pass with no network access
- [x] `cargo clippy --all-targets -- -D warnings` — clean